### PR TITLE
feat: ingest photos via web ui using exif

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,9 @@ docker run -p 8000:8000 -v $(pwd)/photos:/photos photo_trails
 ```
 
 Images placed in the `photos/` directory can then be ingested using the
-`ingest_photo` helper in `app/ingest.py`.
+`ingest_photo` helper in `app/ingest.py`. Photos lacking EXIF metadata are
+skipped with a warning, and all ingested files are copied into the `photos/`
+directory with their metadata stored in the photo database.
+Photos can also be uploaded through the web interface via the *Upload Photo*
+link, which uses the same ingestion process and skips files without EXIF
+metadata.

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,2 +1,13 @@
 html, body, #map { height: 100%; margin: 0; }
 .leaflet-tooltip img { max-width: 200px; }
+#upload-link {
+  position: absolute;
+  z-index: 1000;
+  top: 10px;
+  left: 10px;
+  background: white;
+  padding: 4px 8px;
+  border-radius: 4px;
+  text-decoration: none;
+  color: #000;
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}"/>
 </head>
 <body>
+  <a id="upload-link" href="{{ url_for('upload') }}">Upload Photo</a>
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="{{ url_for('static', filename='map.js') }}"></script>

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>Upload Photo</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}"/>
+</head>
+<body>
+  <h1>Upload Photo</h1>
+  {% if message %}
+    <p>{{ message }}</p>
+  {% endif %}
+  <form action="" method="post" enctype="multipart/form-data">
+    <input type="file" name="photo" accept="image/*" required>
+    <button type="submit">Upload</button>
+  </form>
+  <p><a href="{{ url_for('index') }}">Back to map</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a web upload page that ingests photos and skips files without EXIF
- link the uploader from the map view and style the link overlay
- document that photos can be uploaded through the web interface

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af730a1718832fa8ee3a66bf426d45