### PR TITLE
Handle IFDRational GPS EXIF data correctly

### DIFF
--- a/app/ingest.py
+++ b/app/ingest.py
@@ -29,8 +29,15 @@ def _gps_from_exif(exif: dict) -> tuple[float, float] | None:
         return None
 
     def _convert(value):
-        d, m, s = value
-        return float(d[0]) / d[1] + float(m[0]) / m[1] / 60 + float(s[0]) / s[1] / 3600
+        def _to_float(item):
+            """Return a float from either an IFDRational or (num, den) tuple."""
+            try:
+                return float(item)
+            except TypeError:
+                return float(item[0]) / item[1]
+
+        d, m, s = (_to_float(x) for x in value)
+        return d + m / 60 + s / 3600
 
     lat = _convert(gps_info[2])
     if gps_info[1] == 'S':

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,25 @@
+"""Tests for ingest helpers."""
+
+import sys
+from pathlib import Path
+
+from PIL.TiffImagePlugin import IFDRational
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from app.ingest import _gps_from_exif
+
+
+def test_gps_from_exif_handles_ifdrational():
+    exif = {
+        "GPSInfo": {
+            1: "N",  # latitude reference
+            2: (IFDRational(40, 1), IFDRational(30, 1), IFDRational(0, 1)),
+            3: "W",  # longitude reference
+            4: (IFDRational(74, 1), IFDRational(0, 1), IFDRational(0, 1)),
+        }
+    }
+
+    lat, lon = _gps_from_exif(exif)
+    assert lat == 40.5
+    assert lon == -74.0
+


### PR DESCRIPTION
## Summary
- fix GPS coordinate extraction to accept PIL `IFDRational` values
- add regression test for `_gps_from_exif`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af7589a75c832f96bb802d8a7b990f