### PR TITLE
Improve photo ingestion and storage

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,7 +7,10 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}"/>
 </head>
 <body>
-  <a id="upload-link" href="{{ url_for('upload') }}">Upload Photo</a>
+  <a id="upload-link" href="{{ url_for('upload') }}">Upload Photo(s)</a>
+  <form id="ingest-form" action="{{ url_for('bulk_ingest') }}" method="post" style="display:inline;">
+    <button type="submit">Ingest Data Directory</button>
+  </form>
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="{{ url_for('static', filename='map.js') }}"></script>

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -11,7 +11,7 @@
     <p>{{ message }}</p>
   {% endif %}
   <form action="" method="post" enctype="multipart/form-data">
-    <input type="file" name="photo" accept="image/*" required>
+    <input type="file" name="photos" accept="image/*" multiple webkitdirectory>
     <button type="submit">Upload</button>
   </form>
   <p><a href="{{ url_for('index') }}">Back to map</a></p>

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -3,10 +3,20 @@
 import sys
 from pathlib import Path
 
+from PIL import Image
 from PIL.TiffImagePlugin import IFDRational
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from app.ingest import _gps_from_exif
+from app.database import Photo, get_session, init_db
+from app.ingest import _gps_from_exif, ingest_directory, ingest_photo
+
+
+def _create_image(path: Path) -> None:
+    """Create a tiny JPEG file with minimal EXIF data."""
+    img = Image.new("RGB", (1, 1))
+    exif = Image.Exif()
+    exif[306] = "2023:01:01 00:00:00"  # DateTime tag to ensure EXIF exists
+    img.save(path, exif=exif)
 
 
 def test_gps_from_exif_handles_ifdrational():
@@ -22,4 +32,45 @@ def test_gps_from_exif_handles_ifdrational():
     lat, lon = _gps_from_exif(exif)
     assert lat == 40.5
     assert lon == -74.0
+
+
+def test_ingest_photo_unique_names(tmp_path):
+    init_db(tmp_path / "photos.db")
+    src1 = tmp_path / "src1"
+    src2 = tmp_path / "src2"
+    data_dir = tmp_path / "data"
+    src1.mkdir()
+    src2.mkdir()
+    img1 = src1 / "test.jpg"
+    img2 = src2 / "test.jpg"
+    _create_image(img1)
+    _create_image(img2)
+
+    ingest_photo(img1, data_dir=data_dir)
+    ingest_photo(img2, data_dir=data_dir)
+
+    files = sorted(p.name for p in data_dir.iterdir())
+    assert len(files) == 2
+    assert files[0] != files[1]
+
+    session = get_session()
+    assert session.query(Photo).count() == 2
+
+
+def test_ingest_directory_skips_existing(tmp_path):
+    init_db(tmp_path / "bulk.db")
+    data_dir = tmp_path / "photos"
+    data_dir.mkdir()
+    img1 = data_dir / "one.jpg"
+    img2 = data_dir / "two.jpg"
+    _create_image(img1)
+    _create_image(img2)
+
+    ingest_directory(data_dir)
+    session = get_session()
+    assert session.query(Photo).count() == 2
+
+    # Second call should not duplicate entries
+    ingest_directory(data_dir)
+    assert session.query(Photo).count() == 2
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,39 @@
+"""Tests for web application endpoints."""
+
+from pathlib import Path
+
+from PIL import Image
+
+from app import ingest as ingest_module
+from app.database import Photo, get_session
+from app.web import create_app
+
+
+def _create_image(path: Path) -> None:
+    img = Image.new("RGB", (1, 1))
+    exif = Image.Exif()
+    exif[306] = "2023:01:01 00:00:00"
+    img.save(path, exif=exif)
+
+
+def test_bulk_ingest_endpoint(tmp_path, monkeypatch):
+    data_dir = tmp_path / "photos"
+    data_dir.mkdir()
+    monkeypatch.setattr(ingest_module, "PHOTO_DATA_DIR", data_dir)
+    monkeypatch.setattr("app.web.PHOTO_DATA_DIR", data_dir)
+
+    app = create_app(tmp_path / "photos.db")
+    app.config["TESTING"] = True
+
+    img1 = data_dir / "one.jpg"
+    img2 = data_dir / "two.jpg"
+    _create_image(img1)
+    _create_image(img2)
+
+    client = app.test_client()
+    resp = client.post("/ingest-directory")
+    assert resp.status_code == 302
+
+    session = get_session()
+    assert session.query(Photo).count() == 2
+


### PR DESCRIPTION
## Summary
- Centralize photo data directory in `PHOTO_DATA_DIR`
- Avoid filename collisions when ingesting; support bulk ingestion of existing photos
- Use shared photo directory in web app
- Expose bulk ingestion in web UI and allow uploading multiple photos

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7782cd10832f80a7e452285c878d