### PR TITLE
Fix ingest directory button and cleanup layout

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,13 +1,33 @@
 html, body, #map { height: 100%; margin: 0; }
 .leaflet-tooltip img { max-width: 200px; }
-#upload-link {
+
+#controls {
   position: absolute;
   z-index: 1000;
   top: 10px;
   left: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+#controls a,
+#controls button {
   background: white;
   padding: 4px 8px;
   border-radius: 4px;
   text-decoration: none;
   color: #000;
+  border: none;
+  cursor: pointer;
+}
+
+#message {
+  position: absolute;
+  z-index: 1000;
+  top: 10px;
+  right: 10px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 4px 8px;
+  border-radius: 4px;
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,10 +7,18 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}"/>
 </head>
 <body>
-  <a id="upload-link" href="{{ url_for('upload') }}">Upload Photo(s)</a>
-  <form id="ingest-form" action="{{ url_for('bulk_ingest') }}" method="post" style="display:inline;">
-    <button type="submit">Ingest Data Directory</button>
-  </form>
+  <div id="controls">
+    <a href="{{ url_for('upload') }}">Upload Photo(s)</a>
+    <form id="ingest-form" action="{{ url_for('bulk_ingest') }}" method="post">
+      <button
+        type="submit"
+        title="Ingests all images already placed in the server's photos directory. Copy photos there first; no directory selection is available."
+      >Ingest Data Directory</button>
+    </form>
+  </div>
+  {% if ingested %}
+  <div id="message">{{ ingested }} photo(s) ingested.</div>
+  {% endif %}
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="{{ url_for('static', filename='map.js') }}"></script>

--- a/app/web.py
+++ b/app/web.py
@@ -27,7 +27,8 @@ def create_app(db_path: str | Path = "photos.db") -> Flask:
 
     @app.route("/")
     def index():
-        return render_template("index.html")
+        ingested = request.args.get("ingested", type=int)
+        return render_template("index.html", ingested=ingested)
 
     @app.route("/upload", methods=["GET", "POST"])
     def upload():
@@ -47,8 +48,8 @@ def create_app(db_path: str | Path = "photos.db") -> Flask:
 
     @app.route("/ingest-directory", methods=["POST"])
     def bulk_ingest():
-        ingest_directory(data_dir=photo_dir)
-        return redirect(url_for("index"))
+        photos = ingest_directory(data_dir=photo_dir)
+        return redirect(url_for("index", ingested=len(photos)))
 
     @app.route("/images/<path:filename>")
     def image_file(filename: str):


### PR DESCRIPTION
## Summary
- Group controls in a top-left toolbar and show ingest results on the map page
- Style toolbar items for better visibility and add message container
- Return ingest count from bulk ingest endpoint and display it in the UI
- Clarify bulk ingest behavior via tooltip

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af82be18e8832fac9e121161ebcaba