### PR TITLE
Fix uploads, add DB reset, startup ingestion, and UI debug feedback

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,15 +9,12 @@
 <body>
   <div id="controls">
     <a href="{{ url_for('upload') }}">Upload Photo(s)</a>
-    <form id="ingest-form" action="{{ url_for('bulk_ingest') }}" method="post">
-      <button
-        type="submit"
-        title="Ingests all images already placed in the server's photos directory. Copy photos there first; no directory selection is available."
-      >Ingest Data Directory</button>
+    <form id="clear-form" action="{{ url_for('clear_db') }}" method="post">
+      <button type="submit">Clear Database</button>
     </form>
   </div>
-  {% if ingested %}
-  <div id="message">{{ ingested }} photo(s) ingested.</div>
+  {% if message %}
+  <div id="message">{{ message }}</div>
   {% endif %}
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>

--- a/app/templates/upload.html
+++ b/app/templates/upload.html
@@ -11,8 +11,14 @@
     <p>{{ message }}</p>
   {% endif %}
   <form action="" method="post" enctype="multipart/form-data">
-    <input type="file" name="photos" accept="image/*" multiple webkitdirectory>
-    <button type="submit">Upload</button>
+    <label>Select photo(s):</label>
+    <input type="file" name="photos" accept="image/*" multiple>
+    <button type="submit">Upload Files</button>
+  </form>
+  <form action="" method="post" enctype="multipart/form-data">
+    <label>Select directory:</label>
+    <input type="file" name="photos" accept="image/*" webkitdirectory directory multiple>
+    <button type="submit">Upload Directory</button>
   </form>
   <p><a href="{{ url_for('index') }}">Back to map</a></p>
 </body>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,7 +1,6 @@
 """Tests for web application endpoints."""
 
 from pathlib import Path
-
 from PIL import Image
 
 from app import ingest as ingest_module
@@ -16,24 +15,34 @@ def _create_image(path: Path) -> None:
     img.save(path, exif=exif)
 
 
-def test_bulk_ingest_endpoint(tmp_path, monkeypatch):
+def test_upload_and_clear_endpoints(tmp_path, monkeypatch):
     data_dir = tmp_path / "photos"
     data_dir.mkdir()
     monkeypatch.setattr(ingest_module, "PHOTO_DATA_DIR", data_dir)
     monkeypatch.setattr("app.web.PHOTO_DATA_DIR", data_dir)
 
+    pre_img = data_dir / "pre.jpg"
+    _create_image(pre_img)
+
     app = create_app(tmp_path / "photos.db")
     app.config["TESTING"] = True
 
-    img1 = data_dir / "one.jpg"
-    img2 = data_dir / "two.jpg"
+    session = get_session()
+    assert session.query(Photo).count() == 1
+
+    img1 = tmp_path / "one.jpg"
+    img2 = tmp_path / "two.jpg"
     _create_image(img1)
     _create_image(img2)
 
     client = app.test_client()
-    resp = client.post("/ingest-directory")
+    with img1.open("rb") as f1, img2.open("rb") as f2:
+        data = {"photos": [(f1, "one.jpg"), (f2, "two.jpg")]}
+        resp = client.post("/upload", data=data, content_type="multipart/form-data")
     assert resp.status_code == 302
 
-    session = get_session()
-    assert session.query(Photo).count() == 2
+    assert session.query(Photo).count() == 3
 
+    resp = client.post("/clear-db")
+    assert resp.status_code == 302
+    assert session.query(Photo).count() == 0


### PR DESCRIPTION
## Summary
- Allow uploading individual photos or full directories via separate inputs
- Add button and endpoint to clear ingested photos from the database
- Show user-facing messages for ingestion success and failures
- Automatically ingest any existing photos from `PHOTO_DATA_DIR` when the app starts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af86c8e3a0832fb24d54e74b1fa2a3