### PR TITLE
Improve map marker rendering with clustering

### DIFF
--- a/app/static/map.js
+++ b/app/static/map.js
@@ -6,10 +6,13 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
 fetch('/photos')
   .then(resp => resp.json())
   .then(data => {
+    const markers = L.markerClusterGroup();
     data.forEach(p => {
       if (p.latitude !== null && p.longitude !== null) {
-        const marker = L.circleMarker([p.latitude, p.longitude], { radius: 5 }).addTo(map);
+        const marker = L.marker([p.latitude, p.longitude]);
         marker.bindTooltip(`<img src="${p.url}" alt="photo" />`);
+        markers.addLayer(marker);
       }
     });
+    map.addLayer(markers);
   });

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8"/>
   <title>Photo Trails</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css"/>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}"/>
 </head>
 <body>
@@ -18,6 +20,7 @@
   {% endif %}
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="{{ url_for('static', filename='map.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Include Leaflet.markercluster plugin
- Cluster photo markers to avoid overlap on map

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af89ffc6a4832fb269a0d573c8e0f5