### PR TITLE
Add sidebar layout with database status

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,18 +1,26 @@
-html, body, #map { height: 100%; margin: 0; }
-.leaflet-tooltip img { max-width: 200px; }
-
-#controls {
-  position: absolute;
-  z-index: 1000;
-  top: 10px;
-  left: 10px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+html, body {
+  height: 100%;
+  margin: 0;
 }
 
-#controls a,
-#controls button {
+#layout {
+  display: flex;
+  height: 100%;
+}
+
+#sidebar {
+  width: 300px;
+  box-sizing: border-box;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.9);
+  overflow-y: auto;
+}
+
+#sidebar a,
+#sidebar button {
   background: white;
   padding: 4px 8px;
   border-radius: 4px;
@@ -20,6 +28,10 @@ html, body, #map { height: 100%; margin: 0; }
   color: #000;
   border: none;
   cursor: pointer;
+}
+
+#map {
+  flex: 1;
 }
 
 #message {
@@ -30,6 +42,10 @@ html, body, #map { height: 100%; margin: 0; }
   background: rgba(255, 255, 255, 0.9);
   padding: 4px 8px;
   border-radius: 4px;
+}
+
+.leaflet-tooltip img {
+  max-width: 200px;
 }
 
 #debug-console {

--- a/app/static/uploader.js
+++ b/app/static/uploader.js
@@ -1,10 +1,25 @@
-const { useState, useRef } = React;
+const { useState, useRef, useEffect } = React;
 
 function Uploader() {
   const [message, setMessage] = useState(null);
   const [log, setLog] = useState([]);
+  const [count, setCount] = useState(0);
   const fileRef = useRef(null);
   const dirRef = useRef(null);
+
+  const fetchCount = async () => {
+    try {
+      const resp = await fetch("/photos");
+      const data = await resp.json();
+      setCount(data.length);
+    } catch (err) {
+      setCount(0);
+    }
+  };
+
+  useEffect(() => {
+    fetchCount();
+  }, []);
 
   const upload = async (inputRef) => {
     const files = inputRef.current.files;
@@ -27,6 +42,7 @@ function Uploader() {
       setLog([String(err)]);
     }
     inputRef.current.value = "";
+    fetchCount();
   };
 
   return React.createElement(
@@ -64,7 +80,12 @@ function Uploader() {
       : null,
     log.length > 0
       ? React.createElement("pre", { id: "debug-console" }, log.join("\n"))
-      : null
+      : null,
+    React.createElement(
+      "div",
+      { className: "status-box" },
+      `Database rows: ${count}`
+    )
   );
 }
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,16 +11,18 @@
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
 </head>
 <body>
-  <div id="controls">
-    <div id="uploader-root"></div>
-    <form id="clear-form" action="{{ url_for('clear_db') }}" method="post">
-      <button type="submit">Clear Database</button>
-    </form>
+  <div id="layout">
+    <div id="sidebar">
+      <div id="uploader-root"></div>
+      <form id="clear-form" action="{{ url_for('clear_db') }}" method="post">
+        <button type="submit">Clear Database</button>
+      </form>
+    </div>
+    <div id="map"></div>
   </div>
   {% if message %}
   <div id="message">{{ message }}</div>
   {% endif %}
-  <div id="map"></div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
   <script src="{{ url_for('static', filename='map.js') }}"></script>


### PR DESCRIPTION
## Summary
- Redesign UI to use two-column layout with sidebar controls and map on the right
- Style sidebar and shared controls for a consistent appearance
- Display live database row count in upload panel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afa3e0744c832f8409d9a99bf5784b