### PR TITLE
Modernize sidebar with expandable uploads and status

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -9,25 +9,29 @@ html, body {
 }
 
 #sidebar {
-  width: 300px;
+  width: 320px;
   box-sizing: border-box;
-  padding: 10px;
+  padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  background: rgba(255, 255, 255, 0.9);
+  gap: 16px;
+  background: #f9fafb;
+  border-right: 1px solid #e5e7eb;
+  font-family: system-ui, sans-serif;
   overflow-y: auto;
 }
 
-#sidebar a,
 #sidebar button {
-  background: white;
-  padding: 4px 8px;
+  background: #3b82f6;
+  color: #fff;
+  padding: 6px 12px;
   border-radius: 4px;
-  text-decoration: none;
-  color: #000;
   border: none;
   cursor: pointer;
+}
+
+#sidebar button:hover {
+  background: #2563eb;
 }
 
 #map {
@@ -49,25 +53,51 @@ html, body {
 }
 
 #debug-console {
-  background: #111;
-  color: #0f0;
+  background: #1f2937;
+  color: #d1d5db;
   padding: 8px;
   max-height: 200px;
   overflow-y: auto;
   white-space: pre-wrap;
+  border-radius: 4px;
 }
 
 #upload-panel {
-  background: rgba(255, 255, 255, 0.9);
-  padding: 8px;
-  border-radius: 4px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 12px;
 }
 
 .status-box {
-  background: rgba(255, 255, 255, 0.9);
+  background: #e5e7eb;
   padding: 4px 8px;
   border-radius: 4px;
+}
+
+#sidebar details {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  padding: 8px 12px;
+}
+
+#sidebar details + details {
+  margin-top: 8px;
+}
+
+#sidebar summary {
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+}
+
+#sidebar summary::-webkit-details-marker {
+  display: none;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
 }

--- a/app/static/uploader.js
+++ b/app/static/uploader.js
@@ -49,42 +49,71 @@ function Uploader() {
     "div",
     { id: "upload-panel" },
     React.createElement(
-      "div",
-      null,
-      React.createElement("input", { ref: fileRef, type: "file", accept: "image/*", multiple: true }),
+      "details",
+      { open: true },
+      React.createElement("summary", null, "Upload Files"),
       React.createElement(
-        "button",
-        { onClick: () => upload(fileRef) },
-        "Upload Files"
+        "div",
+        { className: "field" },
+        React.createElement("input", { ref: fileRef, type: "file", accept: "image/*", multiple: true }),
+        React.createElement(
+          "button",
+          { onClick: () => upload(fileRef) },
+          "Upload"
+        )
       )
     ),
     React.createElement(
-      "div",
+      "details",
       null,
-      React.createElement("input", {
-        ref: dirRef,
-        type: "file",
-        accept: "image/*",
-        multiple: true,
-        webkitdirectory: "",
-        directory: "",
-      }),
+      React.createElement("summary", null, "Upload Directory"),
       React.createElement(
-        "button",
-        { onClick: () => upload(dirRef) },
-        "Upload Directory"
+        "div",
+        { className: "field" },
+        React.createElement("input", {
+          ref: dirRef,
+          type: "file",
+          accept: "image/*",
+          multiple: true,
+          webkitdirectory: "",
+          directory: "",
+        }),
+        React.createElement(
+          "button",
+          { onClick: () => upload(dirRef) },
+          "Upload"
+        )
       )
     ),
-    message
-      ? React.createElement("div", { className: "status-box" }, message)
-      : null,
-    log.length > 0
-      ? React.createElement("pre", { id: "debug-console" }, log.join("\n"))
-      : null,
     React.createElement(
-      "div",
-      { className: "status-box" },
-      `Database rows: ${count}`
+      "details",
+      { open: true },
+      React.createElement("summary", null, "Status"),
+      message
+        ? React.createElement("div", { className: "status-box" }, message)
+        : null,
+      log.length > 0
+        ? React.createElement("pre", { id: "debug-console" }, log.join("\n"))
+        : null,
+      React.createElement(
+        "div",
+        { className: "status-box" },
+        `Database rows: ${count}`
+      )
+    ),
+    React.createElement(
+      "details",
+      null,
+      React.createElement("summary", null, "Database"),
+      React.createElement(
+        "form",
+        { action: "/clear-db", method: "post" },
+        React.createElement(
+          "button",
+          { type: "submit" },
+          "Clear Database"
+        )
+      )
     )
   );
 }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,9 +14,6 @@
   <div id="layout">
     <div id="sidebar">
       <div id="uploader-root"></div>
-      <form id="clear-form" action="{{ url_for('clear_db') }}" method="post">
-        <button type="submit">Clear Database</button>
-      </form>
     </div>
     <div id="map"></div>
   </div>


### PR DESCRIPTION
## Summary
- Restyle sidebar with modern fonts, colors, and hoverable buttons
- Add expandable sections for file upload, directory upload, status, and database maintenance
- Restore explicit upload buttons for files and directories with updated status reporting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afa5c70498832f9e3c018c123c9d07